### PR TITLE
Add Tkinter GUI for ecosystem simulation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,14 @@
 from time import sleep
 
 from grid import Grid
+import constants
+import tkinter as tk
 
 
-def run_simulation(width: int = 20, height: int = 10, steps: int = 50, delay: float = 0.5) -> None:
+def run_simulation_console(
+    width: int = 20, height: int = 10, steps: int = 50, delay: float = 0.5
+) -> None:
+    """Run the simulation in the console using text output."""
     grid = Grid(width, height)
     grid.initialize()
     for _ in range(steps):
@@ -12,5 +17,51 @@ def run_simulation(width: int = 20, height: int = 10, steps: int = 50, delay: fl
         sleep(delay)
 
 
+def run_simulation_gui(
+    width: int = 20, height: int = 10, steps: int = 50, delay: int = 500
+) -> None:
+    """Run the simulation with a simple Tkinter GUI."""
+    grid = Grid(width, height)
+    grid.initialize()
+
+    root = tk.Tk()
+    root.title("Ecosystem Simulation")
+
+    labels = [
+        [
+            tk.Label(root, text=constants.ICON_EMPTY, font=("Arial", 20))
+            for _ in range(width)
+        ]
+        for _ in range(height)
+    ]
+    for r in range(height):
+        for c in range(width):
+            labels[r][c].grid(row=r, column=c)
+
+    def update_display() -> None:
+        for r in range(height):
+            for c in range(width):
+                cell = grid.grid[r][c]
+                labels[r][c].config(
+                    text=str(cell) if cell else constants.ICON_EMPTY
+                )
+
+    step_count = 0
+
+    def step() -> None:
+        nonlocal step_count
+        if step_count >= steps:
+            return
+        grid.step()
+        update_display()
+        step_count += 1
+        root.after(delay, step)
+
+    update_display()
+    root.after(delay, step)
+    root.mainloop()
+
+
 if __name__ == "__main__":
-    run_simulation()
+    # Default to GUI when executed directly
+    run_simulation_gui()


### PR DESCRIPTION
## Summary
- introduce `run_simulation_gui` to display the grid in a Tkinter window
- keep console mode via `run_simulation_console`
- default to GUI when running `main.py`

## Testing
- `pytest -q`
- `python main.py` *(fails: `_tkinter.TclError: no display name and no $DISPLAY environment variable`)*

------
https://chatgpt.com/codex/tasks/task_e_684059d6dad88320ad5c3f2201dee748